### PR TITLE
Small fixes

### DIFF
--- a/Run_GUI.py
+++ b/Run_GUI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Created on Fri Feb 22 10:35:01 2019
@@ -7,6 +7,9 @@ Created on Fri Feb 22 10:35:01 2019
 """
 
 import os, sys, serial, time, numpy, configparser, itertools, h5py
+
+from PyQt5 import QtGui
+
 import pyqtgraph as pg
 import pyqtgraph.exporters
 


### PR DESCRIPTION
Fixed shebang to make it more general
PyQt5 has to be imported before pyqtgraph, else pyqtgraph tries to load PyQt4 instead.